### PR TITLE
Only remove text directive

### DIFF
--- a/app/scripts/index.js
+++ b/app/scripts/index.js
@@ -1,8 +1,21 @@
 try {
+  const TEXT_HIGHLIGHT_DIRECTIVE_ID = 'text';
+  const FRAGMENT_DIRECTIVE_SEPARATOR = ':~:';
+
   [...document.querySelectorAll('a')].forEach((link) => {
-    const regex = /#:~:.*$/;
-    if (typeof link.href === 'string' && regex.test(link.href)) {
-      link.href = link.href.replace(regex, '');
+    if (typeof link.href === 'string' && link.href.includes(FRAGMENT_DIRECTIVE_SEPARATOR)) {
+      const url = new URL(link.href);
+      const [ hash, fragmentDirectivesString ] = url.hash.split(FRAGMENT_DIRECTIVE_SEPARATOR);
+
+      const fragmentDirectives = new URLSearchParams(fragmentDirectivesString);
+      fragmentDirectives.delete(TEXT_HIGHLIGHT_DIRECTIVE_ID);
+      const newFragmentDirectivesString = fragmentDirectives.toString();
+
+      url.hash = newFragmentDirectivesString ?
+        `${hash}${FRAGMENT_DIRECTIVE_SEPARATOR}${newFragmentDirectivesString}` :
+        hash;
+
+      link.href = url.href;
     }
   });
 } catch(e) {}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "pack": "rm app.zip; cd app && zip -r ../app.zip *"
+    "pack": "rm app.zip; cd app && zip -r ../app.zip *",
+    "test": "node ./test"
   },
   "devDependencies": {
     "node-fetch": "^2.6.1"

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,111 @@
+const base = 'https://test.com/path';
+const variants = [
+  undefined,
+  null,
+  '',
+  base,
+];
+const HASH_COMBINATIONS = [
+  '#',
+  '#a',
+  '#a=1',
+  '#?a=1',
+  '#?a=1&b=2',
+];
+const FD_COMBINATIONS = [
+  '',
+  ':~:',
+  ':~:a',
+  ':~:a=1',
+  ':~:text',
+  ':~:text=1',
+  ':~:a=1&text=2',
+  ':~:text=1&a=2',
+  ':~:text=1&a',
+  ':~:text&a=1',
+];
+
+HASH_COMBINATIONS.forEach(hc => {
+  FD_COMBINATIONS.forEach(fdc => {
+    variants.push(base + hc + fdc);
+  });
+});
+
+const links = variants.map(v => ({ href: v }));
+global.document = {
+  querySelectorAll: () => links,
+};
+
+// Run!
+require('../app/scripts/index.js');
+const results = links.map(l => l.href);
+
+const expected = [
+  /* Test 0  */ undefined,
+  /* Test 1  */ null,
+  /* Test 2  */ '',
+  /* Test 3  */ 'https://test.com/path',
+  /* Test 4  */ 'https://test.com/path#',
+  /* Test 5  */ 'https://test.com/path#',
+  /* Test 6  */ 'https://test.com/path#:~:a=',
+  /* Test 7  */ 'https://test.com/path#:~:a=1',
+  /* Test 8  */ 'https://test.com/path#',
+  /* Test 9  */ 'https://test.com/path#',
+  /* Test 10 */ 'https://test.com/path#:~:a=1',
+  /* Test 11 */ 'https://test.com/path#:~:a=2',
+  /* Test 12 */ 'https://test.com/path#:~:a=',
+  /* Test 13 */ 'https://test.com/path#:~:a=1',
+  /* Test 14 */ 'https://test.com/path#a',
+  /* Test 15 */ 'https://test.com/path#a',
+  /* Test 16 */ 'https://test.com/path#a:~:a=',
+  /* Test 17 */ 'https://test.com/path#a:~:a=1',
+  /* Test 18 */ 'https://test.com/path#a',
+  /* Test 19 */ 'https://test.com/path#a',
+  /* Test 20 */ 'https://test.com/path#a:~:a=1',
+  /* Test 21 */ 'https://test.com/path#a:~:a=2',
+  /* Test 22 */ 'https://test.com/path#a:~:a=',
+  /* Test 23 */ 'https://test.com/path#a:~:a=1',
+  /* Test 24 */ 'https://test.com/path#a=1',
+  /* Test 25 */ 'https://test.com/path#a=1',
+  /* Test 26 */ 'https://test.com/path#a=1:~:a=',
+  /* Test 27 */ 'https://test.com/path#a=1:~:a=1',
+  /* Test 28 */ 'https://test.com/path#a=1',
+  /* Test 29 */ 'https://test.com/path#a=1',
+  /* Test 30 */ 'https://test.com/path#a=1:~:a=1',
+  /* Test 31 */ 'https://test.com/path#a=1:~:a=2',
+  /* Test 32 */ 'https://test.com/path#a=1:~:a=',
+  /* Test 33 */ 'https://test.com/path#a=1:~:a=1',
+  /* Test 34 */ 'https://test.com/path#?a=1',
+  /* Test 35 */ 'https://test.com/path#?a=1',
+  /* Test 36 */ 'https://test.com/path#?a=1:~:a=',
+  /* Test 37 */ 'https://test.com/path#?a=1:~:a=1',
+  /* Test 38 */ 'https://test.com/path#?a=1',
+  /* Test 39 */ 'https://test.com/path#?a=1',
+  /* Test 40 */ 'https://test.com/path#?a=1:~:a=1',
+  /* Test 41 */ 'https://test.com/path#?a=1:~:a=2',
+  /* Test 42 */ 'https://test.com/path#?a=1:~:a=',
+  /* Test 43 */ 'https://test.com/path#?a=1:~:a=1',
+  /* Test 44 */ 'https://test.com/path#?a=1&b=2',
+  /* Test 45 */ 'https://test.com/path#?a=1&b=2',
+  /* Test 46 */ 'https://test.com/path#?a=1&b=2:~:a=',
+  /* Test 47 */ 'https://test.com/path#?a=1&b=2:~:a=1',
+  /* Test 48 */ 'https://test.com/path#?a=1&b=2',
+  /* Test 49 */ 'https://test.com/path#?a=1&b=2',
+  /* Test 50 */ 'https://test.com/path#?a=1&b=2:~:a=1',
+  /* Test 51 */ 'https://test.com/path#?a=1&b=2:~:a=2',
+  /* Test 52 */ 'https://test.com/path#?a=1&b=2:~:a=',
+  /* Test 53 */ 'https://test.com/path#?a=1&b=2:~:a=1',
+];
+
+const differences = [];
+variants.forEach((variant, index) => {
+  if (results[index] !== expected[index]) {
+    differences.push(`Error for case ${index} (${variant})${'\n'}Expected ${expected[index]}, but got ${results[index]}${'\n'}`);
+  }
+});
+
+if (differences.length) {
+  throw new Error(differences.join('\n'));
+}
+
+console.log('Success!');


### PR DESCRIPTION
This extension is aimed at Google search highlights removal, the highlights are implemented via "text" fragment directive

However there might be other directive, separated with "&" (see [the standard](https://wicg.github.io/scroll-to-text-fragment/#parsing-the-fragment-directive))

This change removes the whole fragment directive section if "text" is the only directive or removes "text" keeps the rest if there're some others

Bonus feature: closes #3

Also adding tests for matching
